### PR TITLE
Potential fix for code scanning alert no. 4: Useless regular-expression character escape

### DIFF
--- a/assets/vendors/glightbox/js/glightbox.js
+++ b/assets/vendors/glightbox/js/glightbox.js
@@ -2061,7 +2061,7 @@
           if (config.trim() !== '') {
             each(data, function (val, key) {
               var str = config;
-              var match = '\s?' + key + '\s?:\s?(.*?)(' + cleanKeys + '\s?:|$)';
+              var match = '\\s?' + key + '\\s?:\\s?(.*?)(' + cleanKeys + '\\s?:|$)';
               var regex = new RegExp(match);
               var matches = str.match(regex);
 


### PR DESCRIPTION
Potential fix for [https://github.com/SurajSatishPawar/SurajSatishPawar.github.io/security/code-scanning/4](https://github.com/SurajSatishPawar/SurajSatishPawar.github.io/security/code-scanning/4)

To fix the problem, we need to ensure that the escape sequence `\s` is correctly represented within the string literal. This means we need to replace `\s` with `\\s` in the string literal. This change will ensure that the regular expression correctly matches whitespace characters.

- Locate the string literal on line 2064 where `\s` is used.
- Replace each occurrence of `\s` with `\\s` to ensure it is correctly interpreted as a whitespace character in the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
