### PR TITLE
Potential fix for code scanning alert no. 3: Useless regular-expression character escape

### DIFF
--- a/assets/vendors/glightbox/js/glightbox.js
+++ b/assets/vendors/glightbox/js/glightbox.js
@@ -2061,7 +2061,7 @@
           if (config.trim() !== '') {
             each(data, function (val, key) {
               var str = config;
-              var match = '\s?' + key + '\s?:\s?(.*?)(' + cleanKeys + '\s?:|$)';
+              var match = '\\s?' + key + '\\s?:\\s?(.*?)(' + cleanKeys + '\\s?:|$)';
               var regex = new RegExp(match);
               var matches = str.match(regex);
 


### PR DESCRIPTION
Potential fix for [https://github.com/SurajSatishPawar/SurajSatishPawar.github.io/security/code-scanning/3](https://github.com/SurajSatishPawar/SurajSatishPawar.github.io/security/code-scanning/3)

To fix the problem, we need to ensure that the escape sequence `\s` is correctly interpreted as a whitespace character in the regular expression. This can be achieved by adding an extra backslash to escape the backslash itself in the string literal. This way, the `RegExp` constructor will correctly interpret `\\s` as `\s`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
